### PR TITLE
feat(cli): add rules subcommand to list all built-in rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ pipeguard scan . --severity high
 pipeguard scan . --severity critical
 ```
 
+### List Built-in Rules
+
+```bash
+# List all rules (table format)
+pipeguard rules
+
+# Output as JSON (machine-readable)
+pipeguard rules --format json
+
+# Filter by category
+pipeguard rules --category SEC
+
+# Filter by severity
+pipeguard rules --severity critical
+
+# Combine filters
+pipeguard rules --category DOC --severity high
+```
+
 ### Fix Suggestions
 
 ```bash

--- a/cmd/pipeguard/main.go
+++ b/cmd/pipeguard/main.go
@@ -4,9 +4,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -21,18 +23,21 @@ var (
 	version = "0.1.0"
 
 	// CLI flags
-	formatFlag   string
-	severityFlag string
-	fixFlag      bool
-	noColorFlag  bool
-	outputFile   string
+	formatFlag    string
+	severityFlag  string
+	fixFlag       bool
+	noColorFlag   bool
+	outputFile    string
+	rulesFormat   string
+	rulesCategory string
+	rulesSeverity string
 )
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "pipeguard",
-		Short: "Pipeline Security & Quality Scanner",
-		Long:  "PipeGuard scans your CI/CD pipelines, Dockerfiles, and Jenkinsfiles\nfor security vulnerabilities and quality issues.\n\n145 built-in rules | Deterministic auto-fix | Zero network\nhttps://pipeguard.dev",
+		Use:     "pipeguard",
+		Short:   "Pipeline Security & Quality Scanner",
+		Long:    "PipeGuard scans your CI/CD pipelines, Dockerfiles, and Jenkinsfiles\nfor security vulnerabilities and quality issues.\n\n145 built-in rules | Deterministic auto-fix | Zero network\nhttps://pipeguard.dev",
 		Version: version,
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
@@ -53,7 +58,18 @@ func main() {
 	scanCmd.Flags().BoolVar(&noColorFlag, "no-color", false, "Disable colored output")
 	scanCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
 
+	rulesCmd := &cobra.Command{
+		Use:   "rules",
+		Short: "Lists all the rules",
+		RunE:  getRules,
+	}
+
+	rulesCmd.Flags().StringVarP(&rulesFormat, "format", "f", "table", "Output Format: table,json")
+	rulesCmd.Flags().StringVar(&rulesCategory, "category", "", "Filter by category (SEC, SAS, SCA, DST, DEP, GOV, JEN, DOC, PQL)")
+	rulesCmd.Flags().StringVarP(&rulesSeverity, "severity", "s", "", "Filter by severity (critical, high, medium, low, info)")
+
 	rootCmd.AddCommand(scanCmd)
+	rootCmd.AddCommand(rulesCmd)
 	rootCmd.SetVersionTemplate(fmt.Sprintf("PipeGuard v%s — Pipeline Security & Quality Scanner by yhakkache\n", version))
 
 	if err := rootCmd.Execute(); err != nil {
@@ -192,4 +208,86 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// getRules handles the "rules" command, listing all rules with optional filtering and formatting
+func getRules(cmd *cobra.Command, args []string) error {
+	engine := rules.NewEngine()
+	allRules := engine.Rules()
+	filtered := filteredRules(allRules)
+	switch strings.ToLower(rulesFormat) {
+	case "json":
+		return rulesJSONFormat(filtered)
+	case "table", "":
+		rulesTableFormat(filtered)
+		return nil
+	default:
+		return fmt.Errorf("unsupported format: %s (use: table, json)", rulesFormat)
+	}
+}
+
+// filters rules based on category and severity flags, then sorts by ID
+func filteredRules(all []*rules.Rule) []*rules.Rule {
+	var result []*rules.Rule
+	for _, r := range all {
+		if rulesCategory != "" &&
+			!strings.EqualFold(string(r.Category), rulesCategory) {
+			continue
+		}
+		if rulesSeverity != "" {
+			if !severityMatches(r.Severity, rulesSeverity) {
+				continue
+			}
+		}
+		result = append(result, r)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ID < result[j].ID
+	})
+	return result
+}
+
+// checks if the rule severity matches the filter
+func severityMatches(ruleSeverity rules.Severity, filter string) bool {
+	switch strings.ToLower(filter) {
+	case "critical":
+		return ruleSeverity == rules.Critical
+	case "high":
+		return ruleSeverity == rules.High
+	case "medium":
+		return ruleSeverity == rules.Medium
+	case "low":
+		return ruleSeverity == rules.Low
+	case "info":
+		return ruleSeverity == rules.Info
+	default:
+		return false
+	}
+}
+
+// prints the all rules in a formatted table
+func rulesTableFormat(rulesList []*rules.Rule) {
+	fmt.Printf("%-6s %-10s %-6s %s\n", "ID", "SEVERITY", "CAT", "DESCRIPTION")
+	fmt.Println(strings.Repeat("-", 80))
+
+	for _, r := range rulesList {
+		fmt.Printf("%-6s %-10s %-6s %s\n",
+			r.ID,
+			r.Severity.String(),
+			r.Category,
+			r.Description,
+		)
+	}
+
+	if len(rulesList) == 0 {
+		fmt.Println("No rules matched the filter.")
+	}
+
+}
+
+// prints the all rules in JSON format
+func rulesJSONFormat(rulesList []*rules.Rule) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", " ")
+	return encoder.Encode(rulesList)
 }


### PR DESCRIPTION
- Adds  command
- Supports table and JSON output
- Adds --category and --severity filters
- Uses existing rules engine for metadata exposure

Closes #3

## Description
<!-- What does this PR do? -->
  This PR adds a new `rules` subcommand that lists all built-in rules in PipeGuard.
  
  ### Features
  - `pipeguard rules` prints formatted table of all rules
  - `pipeguard rules --format json` outputs JSON array
  - `--category` filter support
  - `--severity` filter support
  - Deterministic sorting by rule ID
  
  ### Implementation Details
  - Uses existing `rules.NewEngine()` to fetch rules
  - No changes to rule evaluation logic
  - CLI-only addition

## Related Issue
<!-- Link the issue: Fixes #123 or Closes #123 -->
Cloess #3

## Type of Change
- [ ]  Bug fix (non-breaking change that fixes an issue)
- [x]  New feature (non-breaking change that adds functionality)
- [ ]  New rule (adds a new security/quality rule)
- [ ]  Documentation update
- [ ]  Refactor (no functional changes)
- [ ]  CI/Build change

## Checklist
- [x] My code follows the project's coding standards
- [x] I have run `go test ./... -count=1` and all tests pass
- [ ] I have run `go vet ./...` with no warnings
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org/) format

## If Adding a New Rule
- [ ] Rule ID follows the correct prefix (R/D/J/Q + number)
- [ ] Severity is justified (see [Severity Guide](../CONTRIBUTING.md#severity-guide))
- [ ] `Why` field explains real-world impact
- [ ] Regex tested against real pipeline files
- [ ] Added to the correct `*_rules.go` file

## Screenshots / Output (if applicable)
<!-- Paste terminal output or screenshots -->

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dc33633d-7342-4a66-8bdf-7c549e584434" />

<img width="1917" height="1053" alt="image" src="https://github.com/user-attachments/assets/65408154-dea7-4307-ac9b-164acdf84cd3" />

<img width="1917" height="1053" alt="image" src="https://github.com/user-attachments/assets/f7139387-903d-4416-a75c-809f883d0730" />


