### PR TITLE
Feat/scan category filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ pipeguard scan . --severity high
 
 # Show only critical violations
 pipeguard scan . --severity critical
+
+# Show only specific categories (comma-separated)
+pipeguard scan . --category SEC
+pipeguard scan . --category SEC,DEP
+
+# Combine severity and category filters
+pipeguard scan . --category JEN --severity high
 ```
 
 ### Fix Suggestions

--- a/cmd/pipeguard/main.go
+++ b/cmd/pipeguard/main.go
@@ -23,6 +23,7 @@ var (
 	// CLI flags
 	formatFlag   string
 	severityFlag string
+	categoryFlag string
 	fixFlag      bool
 	noColorFlag  bool
 	outputFile   string
@@ -30,9 +31,9 @@ var (
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "pipeguard",
-		Short: "Pipeline Security & Quality Scanner",
-		Long:  "PipeGuard scans your CI/CD pipelines, Dockerfiles, and Jenkinsfiles\nfor security vulnerabilities and quality issues.\n\n145 built-in rules | Deterministic auto-fix | Zero network\nhttps://pipeguard.dev",
+		Use:     "pipeguard",
+		Short:   "Pipeline Security & Quality Scanner",
+		Long:    "PipeGuard scans your CI/CD pipelines, Dockerfiles, and Jenkinsfiles\nfor security vulnerabilities and quality issues.\n\n145 built-in rules | Deterministic auto-fix | Zero network\nhttps://pipeguard.dev",
 		Version: version,
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
@@ -49,6 +50,7 @@ func main() {
 
 	scanCmd.Flags().StringVarP(&formatFlag, "format", "f", "terminal", "Output format: terminal, json, sarif")
 	scanCmd.Flags().StringVarP(&severityFlag, "severity", "s", "", "Filter by minimum severity: critical, high, medium, low")
+	scanCmd.Flags().StringVarP(&categoryFlag, "category", "c", "", "Filter by category (comma-separated: SEC,SAS,SCA,DST,DEP,GOV,JEN,DOC,PQL)")
 	scanCmd.Flags().BoolVar(&fixFlag, "fix", false, "Show fix suggestions for violations")
 	scanCmd.Flags().BoolVar(&noColorFlag, "no-color", false, "Disable colored output")
 	scanCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
@@ -100,6 +102,22 @@ func runScan(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Parse category filter
+	var allowedCategories map[rules.Category]bool
+	if categoryFlag != "" {
+		allowedCategories = make(map[rules.Category]bool)
+		inputCategories := strings.Split(categoryFlag, ",")
+		for _, cat := range inputCategories {
+			clean := strings.ToUpper(strings.TrimSpace(cat))
+			c := rules.Category(clean)
+
+			if !isValidCategory(c) {
+				return fmt.Errorf("invalid category: %s (use: SEC,SAS,SCA,DST,DEP,GOV,JEN,DOC,PQL)", clean)
+			}
+			allowedCategories[c] = true
+		}
+	}
+
 	// Step 1: Detect files
 	files, err := detector.Detect(absPath)
 	if err != nil {
@@ -137,6 +155,16 @@ func runScan(cmd *cobra.Command, args []string) error {
 			violations = rules.FilterBySeverity(violations, minSeverity)
 		}
 
+		// Apply category filter
+		if allowedCategories != nil {
+			var filtered []rules.Violation
+			for _, v := range violations {
+				if allowedCategories[v.Rule.Category] {
+					filtered = append(filtered, v)
+				}
+			}
+			violations = filtered
+		}
 		// Calculate scores
 		score := scorer.Calculate(violations)
 
@@ -192,4 +220,14 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// isValidCategory checks if the provided category is one of the allowed categories
+func isValidCategory(c rules.Category) bool {
+	switch c {
+	case rules.SEC, rules.SAS, rules.SCA, rules.DST, rules.DEP, rules.GOV, rules.JEN, rules.DOC, rules.PQL:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
This PR adds a new `--category` (`-c`) flag to the `scan` command to allow filtering violations by category code.

### Features
- Supports comma-separated category values (e.g., `SEC,DEP,JEN`)
- Validates input and returns a helpful error for invalid categories
- Applies filtering before scoring and exit code evaluation
- Can be combined with `--severity` filter

### Example Usage
```bash
pipeguard scan . --category SEC
pipeguard scan . --category SEC,DEP
pipeguard scan . --category JEN --severity high
```
## Related Issue
<!-- Link the issue: Fixes #123 or Closes #123 -->
Closes #2

## Type of Change
- [ ]  Bug fix (non-breaking change that fixes an issue)
- [ ]  New feature (non-breaking change that adds functionality)
- [ ]  New rule (adds a new security/quality rule)
- [ ]  Documentation update
- [ ]  Refactor (no functional changes)
- [ ]  CI/Build change

## Checklist
- [x] My code follows the project's coding standards
- [x] I have run `go test ./... -count=1` and all tests pass
- [x] I have run `go vet ./...` with no warnings
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org/) format

## If Adding a New Rule
- [ ] Rule ID follows the correct prefix (R/D/J/Q + number)
- [ ] Severity is justified (see [Severity Guide](../CONTRIBUTING.md#severity-guide))
- [ ] `Why` field explains real-world impact
- [ ] Regex tested against real pipeline files
- [ ] Added to the correct `*_rules.go` file

## Screenshots / Output (if applicable)
<!-- Paste terminal output or screenshots -->
