### PR TITLE
Feat/output html formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RESULTS
 - **4 file types** — GitLab CI, GitHub Actions, Jenkinsfile, Dockerfile
 - **Dual scoring** — Security score (0-100) + Quality score (0-100)
 - **Maturity levels** — Level 0 (None) to Level 5 (Optimized)
-- **3 output formats** — Terminal (ANSI colors), JSON, SARIF v2.1.0
+- **4 output formats** — Terminal (ANSI colors), JSON, HTML, SARIF v2.1.0
 - **Fix suggestions** — deterministic auto-fix descriptions for ~85% of rules
 - **CI/CD gate** — exit code 1 when critical or high violations found
 - **Zero config** — point it at a directory and scan
@@ -102,9 +102,13 @@ pipeguard scan . --format json
 # SARIF v2.1.0 — for GitHub/GitLab Security tabs
 pipeguard scan . --format sarif
 
+# HTML — standalone shareable report
+pipeguard scan . --format html
+
 # Save to file
 pipeguard scan . --format json --output report.json
 pipeguard scan . --format sarif --output report.sarif
+pipeguard scan . --format html --output report.html
 ```
 
 ### Filtering
@@ -242,6 +246,7 @@ pipeguard/
       json.go           JSON formatter
       sarif.go          SARIF v2.1.0 formatter
       colors.go         ANSI color management
+      html.go           Standalone HTML report formatter
 ```
 
 ## Design Principles

--- a/cmd/pipeguard/main.go
+++ b/cmd/pipeguard/main.go
@@ -30,9 +30,9 @@ var (
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "pipeguard",
-		Short: "Pipeline Security & Quality Scanner",
-		Long:  "PipeGuard scans your CI/CD pipelines, Dockerfiles, and Jenkinsfiles\nfor security vulnerabilities and quality issues.\n\n145 built-in rules | Deterministic auto-fix | Zero network\nhttps://pipeguard.dev",
+		Use:     "pipeguard",
+		Short:   "Pipeline Security & Quality Scanner",
+		Long:    "PipeGuard scans your CI/CD pipelines, Dockerfiles, and Jenkinsfiles\nfor security vulnerabilities and quality issues.\n\n145 built-in rules | Deterministic auto-fix | Zero network\nhttps://pipeguard.dev",
 		Version: version,
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
@@ -47,7 +47,7 @@ func main() {
 		RunE:  runScan,
 	}
 
-	scanCmd.Flags().StringVarP(&formatFlag, "format", "f", "terminal", "Output format: terminal, json, sarif")
+	scanCmd.Flags().StringVarP(&formatFlag, "format", "f", "terminal", "Output format: terminal, json, sarif, html")
 	scanCmd.Flags().StringVarP(&severityFlag, "severity", "s", "", "Filter by minimum severity: critical, high, medium, low")
 	scanCmd.Flags().BoolVar(&fixFlag, "fix", false, "Show fix suggestions for violations")
 	scanCmd.Flags().BoolVar(&noColorFlag, "no-color", false, "Disable colored output")
@@ -178,8 +178,11 @@ func runScan(cmd *cobra.Command, args []string) error {
 	case "terminal", "":
 		formatter := output.NewTerminalFormatter(writer, fixFlag)
 		formatter.FormatReport(results)
+	case "html":
+		formatter := output.NewHTMLFormatter(writer)
+		formatter.FormatReport(results)
 	default:
-		return fmt.Errorf("unsupported format: %s (use: terminal, json, sarif)", formatFlag)
+		return fmt.Errorf("unsupported format: %s (use: terminal, json, sarif, html)", formatFlag)
 	}
 
 	// Exit code: non-zero if critical or high violations found

--- a/pkg/output/html.go
+++ b/pkg/output/html.go
@@ -1,0 +1,107 @@
+package output
+
+import (
+	"html/template"
+	"io"
+	"time"
+)
+
+type HTMLFomatter struct {
+	writer io.Writer
+}
+
+// creates a new HTMLFomatter with the provided writer.
+func NewHTMLFormatter(w io.Writer) *HTMLFomatter {
+	return &HTMLFomatter{writer: w}
+}
+
+// generates an HTML report based on the provided results and writes it to the formatter's writer.
+func (f *HTMLFomatter) FormatReport(results []FileResult) {
+	tmpl := template.Must(template.New("report").Parse(htmlTemplate))
+
+	data := struct {
+		Timestamp string
+		Results   []FileResult
+	}{
+		Timestamp: time.Now().Format(time.RFC1123),
+		Results:   results,
+	}
+	_ = tmpl.Execute(f.writer, data)
+}
+
+// HTML template for displaying the report.
+const htmlTemplate = `
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>PipeGuard Report</title>
+<style>
+body {
+	font-family: Arial, sans-serif;
+	background-color: #f4f6f8;
+	padding: 20px;
+}
+h1 {
+	color: #333;
+}
+table {
+	border-collapse: collapse;
+	width: 100%;
+	margin-bottom: 30px;
+	background: white;
+}
+th, td {
+	border: 1px solid #ddd;
+	padding: 8px;
+	text-align: left;
+}
+th {
+	background-color: #222;
+	color: white;
+}
+.CRITICAL { color: #b00020; font-weight: bold; }
+.HIGH { color: #e65100; font-weight: bold; }
+.MEDIUM { color: #f9a825; }
+.LOW { color: #2e7d32; }
+.INFO { color: #1565c0; }
+.file-header {
+	margin-top: 30px;
+	font-size: 18px;
+	font-weight: bold;
+}
+</style>
+</head>
+<body>
+
+<h1>PipeGuard Scan Report</h1>
+<p><strong>Generated:</strong> {{ .Timestamp }}</p>
+
+{{ range .Results }}
+<div class="file-header">{{ .Path }} ({{ .FileType }})</div>
+
+<table>
+<tr>
+<th>Severity</th>
+<th>Rule ID</th>
+<th>Description</th>
+<th>Line</th>
+<th>Content</th>
+</tr>
+
+{{ range .Violations }}
+<tr>
+<td class="{{ .Rule.Severity }}">{{ .Rule.Severity }}</td>
+<td>{{ .Rule.ID }}</td>
+<td>{{ .Rule.Description }}</td>
+<td>{{ .Line }}</td>
+<td>{{ .Content }}</td>
+</tr>
+{{ end }}
+
+</table>
+{{ end }}
+
+</body>
+</html>
+`


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
This PR adds a new standalone HTML output formatter to PipeGuard.

The formatter generates a self-contained HTML report using Go’s `html/template`, enabling shareable and executive-friendly scan reports. The output includes severity-based color styling and integrates seamlessly with the existing scan results pipeline.

The feature supports:
- `--format html` for stdout output  
- `--output report.html` for file export  
- Inline CSS (no external dependencies)  
- Severity-aware styling (CRITICAL, HIGH, MEDIUM, LOW, INFO)

This implementation follows the same formatter pattern as the existing JSON and SARIF formatters and maintains PipeGuard’s deterministic, zero-network design principles.

## Related Issue
<!-- Link the issue: Fixes #123 or Closes #123 -->
Closes #1 
## Type of Change
- [ ]  Bug fix (non-breaking change that fixes an issue)
- [ ]  New feature (non-breaking change that adds functionality)
- [ ]  New rule (adds a new security/quality rule)
- [ ]  Documentation update
- [ ]  Refactor (no functional changes)
- [ ]  CI/Build change

## Checklist
- [x] My code follows the project's coding standards
- [x] I have run `go test ./... -count=1` and all tests pass
- [x] I have run `go vet ./...` with no warnings
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org/) format

## If Adding a New Rule
- [ ] Rule ID follows the correct prefix (R/D/J/Q + number)
- [ ] Severity is justified (see [Severity Guide](../CONTRIBUTING.md#severity-guide))
- [ ] `Why` field explains real-world impact
- [ ] Regex tested against real pipeline files
- [ ] Added to the correct `*_rules.go` file

## Screenshots / Output (if applicable)
<!-- Paste terminal output or screenshots -->
